### PR TITLE
Docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ GrapeSwagger.model_parsers.register(GrapeSwagger::FastJsonapi::Parser, BaseSeria
 desc 'Get current user' do
   success code: 200, model: UserSerializer, message: 'The current user'
 # [...]
+end
 ```
 
 Note that you **need** the `grape-swagger` gem for this to work, otherwise it will throw an error.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ When using Grape with Swagger via [grape-swagger](https://github.com/ruby-grape/
 
 ```ruby
 # FastJsonapi serializer example
+
+# app/serializers/base_serializer.rb
+class BaseSerializer; end
 # app/serializers/user_serializer.rb
-class UserSerializer
+class UserSerializer < BaseSerializer
   include FastJsonapi::ObjectSerializer
 
   set_type :user
@@ -48,11 +51,11 @@ class UserSerializer
 end
 
 # config/initializers/grape_swagger.rb
-GrapeSwagger.model_parsers.register(GrapeSwagger::FastJsonapi::Parser, UserSerializer)
+GrapeSwagger.model_parsers.register(GrapeSwagger::FastJsonapi::Parser, BaseSerializer)
 
 # Your grape API endpoint
-desc 'Get current user',
-  success: { code: 200, model: UserSerializer, message: 'The current user' }
+desc 'Get current user' do
+  success code: 200, model: UserSerializer, message: 'The current user'
 # [...]
 ```
 


### PR DESCRIPTION
Modernize  the docs. Swagger deprecated the options hash for options block. Modernize the usage example so it can work with more than one serializer.  `GrapeSwagger.model_parsers.register` only accepts a single base class per parser, let's add a wrapper so we can use this for more than a single serializer 