### PR TITLE
Handle serializers which don't have any attributes

### DIFF
--- a/lib/grape_fast_jsonapi/parser.rb
+++ b/lib/grape_fast_jsonapi/parser.rb
@@ -83,7 +83,7 @@ module GrapeSwagger
 
       def map_model_attributes
         attributes = {}
-        model.attributes_to_serialize.each do |attribute, _|
+        (model.attributes_to_serialize || []).each do |attribute, _|
           attributes[attribute] = :string
         end
         attributes

--- a/spec/lib/grape_fast_jsonapi/parser_spec.rb
+++ b/spec/lib/grape_fast_jsonapi/parser_spec.rb
@@ -126,6 +126,53 @@ describe GrapeSwagger::FastJsonapi::Parser do
           })
         end
       end
+      context 'when the serializer doesn\'t have any attributes' do
+        let(:model) { AnotherBlogPostSerializer } # no attributes
+
+        it 'return a hash defining the schema with empty attributes' do
+          expect(subject).to eq({
+            data: {
+              type: :object,
+              properties: {
+                id: { type: :integer },
+                type: { type: :string },
+                attributes: {
+                  type: :object,
+                  properties: {}
+                },
+                relationships: {
+                  type: :object,
+                  properties: {
+                    user: {
+                      properties: {
+                        data: {
+                          properties: {
+                            id: { type: :integer },
+                            type: { type: :string }
+                          },
+                          type: :object,
+                        }
+                      },
+                      type: :object,
+                    }
+                  }
+                }
+              },
+              example: {
+                id: 1,
+                type: :blog_post,
+                attributes: {
+                },
+                relationships: {
+                  user: {
+                    data: { id: 1, type: :user }
+                  }
+                }
+              }
+            }
+          })
+        end
+      end
     end
   end
 end

--- a/spec/support/serializers/another_blog_post_serializer.rb
+++ b/spec/support/serializers/another_blog_post_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AnotherBlogPostSerializer
+  include FastJsonapi::ObjectSerializer
+
+  set_type :blog_post
+
+  belongs_to :user
+end


### PR DESCRIPTION
Without this change the library raises exception with serializers with no attributes defined. In that case `model.attributes_to_serialize` returns `nil` and causes undefined method exception.