### PR TITLE
Revert to model_name instead of class-name

### DIFF
--- a/lib/grape_fast_jsonapi/formatter.rb
+++ b/lib/grape_fast_jsonapi/formatter.rb
@@ -58,7 +58,7 @@ module Grape
           klass_name ||= begin
             object = object.first if object.is_a?(Array)
 
-            object.class.name + 'Serializer'
+            (object.try(:model_name) || object.class).name + 'Serializer'
           end
 
           klass_name&.safe_constantize

--- a/spec/lib/grape_fast_jsonapi/formatter_spec.rb
+++ b/spec/lib/grape_fast_jsonapi/formatter_spec.rb
@@ -11,6 +11,9 @@ describe Grape::Formatter::FastJsonapi do
     let(:blog_post) do
       BlogPost.new(id: 1, title: "Blog Post title", body: "Blog post body")
     end
+    let(:admin) do
+      UserAdmin.new(id: 1, first_name: 'Jean Luc', last_name: 'Picard', password: 'supersecretpassword', email: 'jeanluc@picard.com')
+    end
 
     describe '.call' do
       subject { described_class.call(object, env) }
@@ -27,6 +30,11 @@ describe Grape::Formatter::FastJsonapi do
         let(:user_serializer) { UserSerializer.new(object, {}) }
         let(:another_user_serializer) { AnotherUserSerializer.new(object, {}) }
         let(:blog_post_serializer) { BlogPostSerializer.new(object, {}) }
+
+        context 'when the object has a model_name defined' do
+          let(:object) { admin }
+          it { is_expected.to eq ::Grape::Json.dump(user_serializer.serializable_hash) }
+        end
 
         context 'when the object is a active serializable model instance' do
           let(:object) { user }

--- a/spec/support/models/user_admin.rb
+++ b/spec/support/models/user_admin.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class UserAdmin
+  include ActiveModel::Serialization
+
+  attr_accessor :id, :first_name, :last_name, :password, :email
+
+  def initialize(params = {})
+    params.each do |k, v|
+      instance_variable_set("@#{k}", v) unless v.nil?
+    end
+  end
+
+  def attributes
+    {
+      'id' => nil,
+      'first_name' => nil,
+      'last_name' => nil,
+      'password' => nil,
+      'email' => nil
+    }
+  end
+
+  def blog_post_ids
+    []
+  end
+
+  def model_name
+    ActiveModel::Name.new(User)
+  end
+end


### PR DESCRIPTION
This PR reverts back to the use of `object.model_name.name` instead of `object.class.name`, in the formatter serializable_class method. When you try to render ActiveRecord relations like: `User.where(xyz)` you'll get a `ActiveRecord::RelationSerializer`, instead of the `UserSerializer`.

I've traced back the change to this commit: https://github.com/EmCousin/grape_fast_jsonapi/commit/2169bec2b1df64553adab5ff9950295a16be07fa

I've noticed the following change in `Grape::Formatter::FastJsonapi.serializable_class:61`. In this commit the `object.model_name.name` was replaced with: `object.class.name`.

I would be happy to provide some test cases to this PR when required as well.